### PR TITLE
Add customFindChunks as param to find all

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -5,6 +5,7 @@
 export const findAll = ({
   autoEscape,
   caseSensitive = false,
+  findChunks = findChunks,
   sanitize,
   searchWords,
   textToHighlight

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,14 +5,14 @@
 export const findAll = ({
   autoEscape,
   caseSensitive = false,
-  customFindChunks = findChunks,
+  findChunks = defaultFindChunks,
   sanitize,
   searchWords,
   textToHighlight
 }) => (
   fillInChunks({
     chunksToHighlight: combineChunks({
-      chunks: customFindChunks({
+      chunks: findChunks({
         autoEscape,
         caseSensitive,
         sanitize,
@@ -60,7 +60,7 @@ export const combineChunks = ({
  * If we find matches, add them to the returned array as a "chunk" object ({start:number, end:number}).
  * @return {start:number, end:number}[]
  */
-export const findChunks = ({
+const defaultFindChunks = ({
   autoEscape,
   caseSensitive,
   sanitize = identity,
@@ -99,6 +99,9 @@ export const findChunks = ({
       return chunks
     }, [])
 }
+// Allow the findChunks to be overridden in findAll,
+// but for backwards compatibility we export as the old name
+export {defaultFindChunks as findChunks}
 
 /**
  * Given a set of chunks to highlight, create an additional set of chunks

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,14 +5,14 @@
 export const findAll = ({
   autoEscape,
   caseSensitive = false,
-  findChunks = findChunks,
+  customFindChunks = findChunks,
   sanitize,
   searchWords,
   textToHighlight
 }) => (
   fillInChunks({
     chunksToHighlight: combineChunks({
-      chunks: findChunks({
+      chunks: customFindChunks({
         autoEscape,
         caseSensitive,
         sanitize,

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -120,4 +120,19 @@ describe('utils', () => {
         {start: 22, end: 23},
     ])
   })
+
+  it('should use customFindChunks', () => {
+    const filledInChunks = Chunks.findAll({
+      customFindChunks: () => (
+       [{start: 2, end: 5}]
+      ),
+      searchWords: ['xxx'],
+      textToHighlight: TEXT
+    })
+    expect(filledInChunks).to.eql([
+      {start: 0, end: 2, highlight: false},
+      {start: 2, end: 5, highlight: true},
+      {start: 5, end: 38, highlight: false}
+    ])
+  })
 })

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -121,18 +121,29 @@ describe('utils', () => {
     ])
   })
 
-  it('should use customFindChunks', () => {
-    const filledInChunks = Chunks.findAll({
-      customFindChunks: () => (
-       [{start: 2, end: 5}]
+  it('should use custom findChunks', () => {
+    let filledInChunks = Chunks.findAll({
+      findChunks: () => (
+       [{start: 1, end: 3}]
       ),
       searchWords: ['xxx'],
       textToHighlight: TEXT
     })
     expect(filledInChunks).to.eql([
-      {start: 0, end: 2, highlight: false},
-      {start: 2, end: 5, highlight: true},
-      {start: 5, end: 38, highlight: false}
+      {start: 0, end: 1, highlight: false},
+      {start: 1, end: 3, highlight: true},
+      {start: 3, end: 38, highlight: false}
+    ])
+
+    filledInChunks = Chunks.findAll({
+      findChunks: () => (
+       []
+      ),
+      searchWords: ['This'],
+      textToHighlight: TEXT
+    })
+    expect(filledInChunks).to.eql([
+      {start: 0, end: 38, highlight: false}
     ])
   })
 })


### PR DESCRIPTION
see https://github.com/bvaughn/react-highlight-words/issues/43

I needed to name the passed arg to `customFindChunks` because when it was called simply `findChunks` then there would be two `findChunks` in the scope.