### PR TITLE
Move babel-preset-flow to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "babel-eslint": "^6.0.4",
     "babel-loader": "^6.2.3",
     "babel-preset-es2015": "^6.14.0",
+    "babel-preset-flow": "^6",
     "cross-env": "^1.0.7",
     "expect.js": "^0.3.1",
     "latinize": "^0.3.0",
@@ -61,8 +62,5 @@
     "rimraf": "^2.4.3",
     "standard": "^7.0.1",
     "webpack": "^1.9.6"
-  },
-  "dependencies": {
-    "babel-preset-flow": "^6"
   }
 }


### PR DESCRIPTION
Since it's only used during the build.

Fixes #11.