### PR TITLE
Enable highlighting in HTML content

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The `findAll` function accepts several parameters, although only the `searchWord
 | sanitize |  | `Function` | Custom sanitize function (advanced) |
 | searchWords | ✅ | `Array<string>` | Array of words to search for |
 | textToHighlight | ✅ | `string` | Text to search and highlight |
+| htmlText        |    | `boolean`| The text is HTML and tags should not be highlighted |
 
 
 ## License

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -146,4 +146,81 @@ describe('utils', () => {
       {start: 0, end: 38, highlight: false}
     ])
   })
+
+  context('when htmlText is not set', () => {
+    it('finds chunks in the text and tags', () => {
+      let result = Chunks.findAll({
+        searchWords: ['strong'],
+        textToHighlight: '<p>There is <strong>some strong content</strong> in this paragraph</p>'
+      })
+
+      expect(result).to.eql([
+        { start: 0, end: 13, highlight: false },
+        { start: 13, end: 19, highlight: true },
+        { start: 19, end: 25, highlight: false },
+        { start: 25, end: 31, highlight: true },
+        { start: 31, end: 41, highlight: false },
+        { start: 41, end: 47, highlight: true },
+        { start: 47, end: 70, highlight: false }
+      ])
+    })
+  })
+
+  context('when htmlText is set to true', () => {
+    it('finds chunks in the text', () => {
+      let result = Chunks.findAll({
+        searchWords: ['content'],
+        textToHighlight: '<p>There is some content in this paragraph</p>',
+        htmlText: true
+      })
+
+      expect(result).to.eql([
+        { start: 0, end: 17, highlight: false },
+        { start: 17, end: 24, highlight: true },
+        { start: 24, end: 46, highlight: false }
+      ])
+    })
+
+    it('does not find chunks in the tags', () => {
+      let result = Chunks.findAll({
+        searchWords: ['strong'],
+        textToHighlight: '<p>There is <strong>some strong content</strong> in this paragraph</p>',
+        htmlText: true
+      })
+
+      expect(result).to.eql([
+        { start: 0, end: 25, highlight: false },
+        { start: 25, end: 31, highlight: true },
+        { start: 31, end: 70, highlight: false }
+      ])
+    })
+
+    it('does not find chunks in the tags metadata', () => {
+      let result = Chunks.findAll({
+        searchWords: ['strong'],
+        textToHighlight: '<p>There is <span class="strong">some strong content</span> in this paragraph</p>',
+        htmlText: true
+      })
+
+      expect(result).to.eql([
+        { start: 0, end: 38, highlight: false },
+        { start: 38, end: 44, highlight: true },
+        { start: 44, end: 81, highlight: false }
+      ])
+    })
+
+    it('support weird cases', () => {
+      let result = Chunks.findAll({
+        searchWords: ['strong'],
+        textToHighlight: '<p aria-strong=1>There is <span class="strong">some < not so stong > content</span> in this paragraph</p>',
+        htmlText: true
+      })
+
+      expect(result).to.eql([
+        { start: 0, end: 8, highlight: false },
+        { start: 8, end: 14, highlight: true },
+        { start: 14, end: 105, highlight: false }
+      ])
+    })
+  })
 })


### PR DESCRIPTION
I'm trying to integrate `react-highlight-words` in a page where highlighting needs to be done on rendered HTML from one markdown (the project its Cucumber new HTML report).

In this PR, I've added a new parameter `htmlText` to `findAll` that tells if the content is HTML. It will not try to highlight the HTML markup, but only the text inside.

I've added some test displaying the original behaviour and also the one when the flag is set. I've also updated the documentation.

Another PR should follow soon on `react-highlight-words` enabling raw HTML to be highlighted.