### PR TITLE
fix: escape regex when square brackets are present

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -170,5 +170,5 @@ function defaultSanitize (string: string): string {
 }
 
 function escapeRegExpFn (string: string): string {
-  return string.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')
+  return string.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,7 @@ export type Chunk = {|
  * @return Array of "chunks" (where a Chunk is { start:number, end:number, highlight:boolean })
  */
 export const findAll = ({
-  autoEscape,
+  autoEscape = true,
   caseSensitive = false,
   findChunks = defaultFindChunks,
   sanitize,
@@ -78,7 +78,7 @@ export const combineChunks = ({
  * @return {start:number, end:number}[]
  */
 const defaultFindChunks = ({
-  autoEscape,
+  autoEscape = true,
   caseSensitive,
   sanitize = defaultSanitize,
   searchWords,
@@ -170,5 +170,5 @@ function defaultSanitize (string: string): string {
 }
 
 function escapeRegExpFn (string: string): string {
-  return string.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
+  return string.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')
 }

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -66,6 +66,17 @@ describe('utils', () => {
       {start: 9, end: 14, highlight: false}
     ])
   })
+  
+  it('should handle unclosed square brackets when autoEscape prop is truthy', () => {
+    const rawChunks = Chunks.findChunks({
+      autoEscape: true,
+      searchWords: ['text['],
+      textToHighlight: ']This is text['
+    })
+    expect(rawChunks).to.eql([
+      {start: 9, end: 14, highlight: false}
+    ])
+  })
 
   it('should match terms without accents against text with accents', () => {
     const rawChunks = Chunks.findChunks({

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -66,17 +66,6 @@ describe('utils', () => {
       {start: 9, end: 14, highlight: false}
     ])
   })
-  
-  it('should handle unclosed square brackets when autoEscape prop is truthy', () => {
-    const rawChunks = Chunks.findChunks({
-      autoEscape: true,
-      searchWords: ['text['],
-      textToHighlight: ']This is text['
-    })
-    expect(rawChunks).to.eql([
-      {start: 9, end: 14, highlight: false}
-    ])
-  })
 
   it('should match terms without accents against text with accents', () => {
     const rawChunks = Chunks.findChunks({


### PR DESCRIPTION
Stumbled across react-highlight-words library and noticed that when I add "[" character, it breaks the whole app.

This PR should fix both packages.

![image](https://user-images.githubusercontent.com/21077089/221176622-6463d247-db4b-4ac4-992d-871f7eadf88d.png)
![image](https://user-images.githubusercontent.com/21077089/221177024-50c37847-3ccf-4dc1-ab46-40f07f9b641a.png)
