### PR TITLE
fix: combine two chunks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "highlight-words-core",
   "description": "Utility functions shared by react-highlight-words and react-native-highlight-words",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/utils.js
+++ b/src/utils.js
@@ -57,9 +57,9 @@ export const combineChunks = ({
       } else {
         // ... subsequent chunks get checked to see if they overlap...
         const prevChunk = processedChunks.pop()
-        if (nextChunk.start <= prevChunk.end) {
+        if (nextChunk.start < prevChunk.end) {
           // It may be the case that prevChunk completely surrounds nextChunk, so take the
-          // largest of the end indeces.
+          // largest of the end indexes.
           const endIndex = Math.max(prevChunk.end, nextChunk.end)
           processedChunks.push({highlight: false, start: prevChunk.start, end: endIndex})
         } else {


### PR DESCRIPTION
When the next chunk is immediately after the pervious one, they should not be merged, as they don't overlap.

